### PR TITLE
Add account name to webhook JSON payload

### DIFF
--- a/src/lib/scheduler/sendDuePosts.ts
+++ b/src/lib/scheduler/sendDuePosts.ts
@@ -17,6 +17,28 @@ function isLocalhostBaseUrl(url: string): boolean {
 	}
 }
 
+/** Display name for webhooks: `user.name` when set, otherwise `user.email`. */
+function accountNameForWebhook(
+	db: ReturnType<typeof getDatabase>,
+	accountId: string
+): string {
+	const row = db.prepare('SELECT name, email FROM user WHERE id = ?').get(accountId) as
+		| { name: string | null; email: string | null }
+		| undefined;
+	const trimmed = row?.name?.trim();
+	if (trimmed) return trimmed;
+	return row?.email ?? '';
+}
+
+/** Adds `account_name` on every outbound webhook body (after payload / override). */
+function mergeAccountNameIntoBody(
+	db: ReturnType<typeof getDatabase>,
+	body: Record<string, unknown>,
+	accountId: string
+): Record<string, unknown> {
+	return { ...body, account_name: accountNameForWebhook(db, accountId) };
+}
+
 /** Merge id and optional callback_url into the body sent to Make.com. */
 function injectCallbackPayload(
 	db: ReturnType<typeof getDatabase>,
@@ -144,12 +166,8 @@ export async function sendDuePosts(): Promise<{ sent: number; failed: number; er
 			insertSendLog(db, post.account_id, post.id, post.payload_override ?? '', null, resolved.error, false);
 			continue;
 		}
-		const bodyWithCallback = injectCallbackPayload(
-			db,
-			resolved.body as Record<string, unknown>,
-			post.id,
-			post.account_id
-		);
+		const withAccount = mergeAccountNameIntoBody(db, resolved.body as Record<string, unknown>, post.account_id);
+		const bodyWithCallback = injectCallbackPayload(db, withAccount, post.id, post.account_id);
 		const requestJson = JSON.stringify(bodyWithCallback);
 
 		let lastError: string | null = null;
@@ -263,12 +281,8 @@ export async function sendPost(postId: string, accountId: string): Promise<SendP
 		insertSendLog(db, accountId, post.id, post.payload_override ?? '', null, resolved.error, false);
 		return { success: false, error: resolved.error, responseStatus: null, responseBody: resolved.error };
 	}
-	const bodyWithCallback = injectCallbackPayload(
-		db,
-		resolved.body as Record<string, unknown>,
-		post.id,
-		accountId
-	);
+	const withAccount = mergeAccountNameIntoBody(db, resolved.body as Record<string, unknown>, accountId);
+	const bodyWithCallback = injectCallbackPayload(db, withAccount, post.id, accountId);
 	const requestJson = JSON.stringify(bodyWithCallback);
 	const updateSent = db.prepare(
 		"UPDATE post SET status = 'sent', sent_at = datetime('now'), error_message = NULL, updated_at = datetime('now') WHERE id = ?"

--- a/tests/lib/sendDuePosts.test.ts
+++ b/tests/lib/sendDuePosts.test.ts
@@ -125,4 +125,28 @@ describe('sendPost', () => {
 		const st = (db.prepare('SELECT status FROM post WHERE id = ?').get(postId) as { status: string }).status;
 		expect(st).toBe('sent');
 	});
+
+	it('includes account_name in webhook JSON (name, else email)', async () => {
+		const db = getDatabase();
+		const postId = 'send-account-name';
+		db.prepare(
+			`INSERT OR REPLACE INTO post (id, account_id, webhook_id, title, status, created_at, updated_at)
+       VALUES (?, ?, ?, ?, 'draft', datetime('now'), datetime('now'))`
+		).run(postId, TEST_USER_ID, TEST_WEBHOOK_ID, 'Z');
+		db.prepare('UPDATE user SET name = ? WHERE id = ?').run('Account Display', TEST_USER_ID);
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			statusText: 'OK',
+			text: async () => '{}'
+		});
+		vi.stubGlobal('fetch', fetchMock);
+		const r = await sendPost(postId, TEST_USER_ID);
+		expect(r.success).toBe(true);
+		const firstCall = fetchMock.mock.calls[0];
+		expect(firstCall).toBeDefined();
+		const body = JSON.parse(firstCall![1].body as string) as { account_name: string };
+		expect(body.account_name).toBe('Account Display');
+		db.prepare('UPDATE user SET name = NULL WHERE id = ?').run(TEST_USER_ID);
+	});
 });


### PR DESCRIPTION
- Introduced `accountNameForWebhook` function to determine the display name for webhooks, prioritizing user name over email.
- Updated `mergeAccountNameIntoBody` function to include `account_name` in the outbound webhook body.
- Modified `sendDuePosts` and `sendPost` functions to integrate the new account name into the webhook payload.
- Added a test case to verify the inclusion of `account_name` in the webhook JSON, ensuring correct functionality.